### PR TITLE
ci: use maintained version of setup zig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@v2
+        uses: mlugg/setup-zig@v2
         with:
-          version: master
+          version: 0.15.2
 
       - name: Build Release
         run: make build-release


### PR DESCRIPTION
previous version no longer maintained, use up to date fork